### PR TITLE
Add support for custom module naming

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,18 @@ module.exports = function (grunt) {
 					src: ['foo.js', 'bar.js']
 				}]
 			},
+			renamed: {
+				options: {
+					moduleName: function (filePath) {
+						return 'appkit/' + filePath;
+					}
+				},
+				files: [{
+					expand: true,
+					cwd: path.join(__dirname, 'tests', 'fixtures', 'renamed'),
+					src: ['foo.js', 'bar.js']
+				}]
+			},
 			fail: {
 				files: [{
 					expand: true,

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "grunt-es6-import-validate",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A Grunt task for validating ES6 Module import statements",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/jshint/bin/jshint Gruntfile.js tasks/*.js tests/**/*.js && grunt validate-imports:ok"
+    "test": "node_modules/jshint/bin/jshint Gruntfile.js tasks/*.js tests/**/*.js && grunt validate-imports:ok validate-imports:renamed"
   },
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
   "dependencies": {
     "bluebird": "~1.0.0",
     "lodash-node": "~2.4.1",
-    "es6-import-validate": "~0.0.2"
+    "es6-import-validate": "~0.0.3"
   },
   "devDependencies": {
     "jshint": "~2.4.3"

--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -5,21 +5,43 @@ var _ = require('lodash-node'),
 
 var ES6ModuleFile = require('es6-import-validate').ES6ModuleFile;
 
+var defaultModuleNamer = function (name) {
+	return name;
+};
+
 module.exports = function (grunt) {
 	grunt.registerMultiTask('validate-imports', function () {
 		var done = this.async(),
+			opts = this.options({
+				moduleName: defaultModuleNamer
+			}),
 			// Group everything by cwd value
 			moduleFiles = this.files.reduce(function (all, file) {
 				all[file.orig.cwd] = all[file.orig.cwd] || [];
 				all[file.orig.cwd] = all[file.orig.cwd].concat(file.src);
 				
 				return all;
-			}, {});
+			}, {}),
+			// Create a customized ES6ModuleFile that allows custom module name to be set
+			TaskES6ModuleFile = function () {
+				ES6ModuleFile.apply(this, _.toArray(arguments));
+			};
+
+		// Inherit from ES6ModuleFile
+		TaskES6ModuleFile.prototype = Object.create(ES6ModuleFile.prototype);
+
+		// Allow the moduleName option to customize the module name
+		TaskES6ModuleFile.prototype.getModuleName = function (filePath) {
+			var name = ES6ModuleFile.prototype.getModuleName.apply(this, _.toArray(arguments));
+
+			return opts.moduleName(name);
+		};
 
 		// Validate each grouping (usually only one)
 		var allValidations = _.map(moduleFiles, function (files, cwd) {
 				return ES6ModuleFile.validateImports(files, {
-						cwd: cwd
+						cwd: cwd,
+						ES6ModuleFile: TaskES6ModuleFile
 					})
 					.then(function (info) {
 						grunt.log.ok('' + files.length + ' files validated.');

--- a/tests/fixtures/renamed/bar.js
+++ b/tests/fixtures/renamed/bar.js
@@ -1,0 +1,10 @@
+
+import foo from 'appkit/foo';
+
+var bar = {
+	property: true
+};
+
+export { bar };
+
+export default bar;

--- a/tests/fixtures/renamed/baz.js
+++ b/tests/fixtures/renamed/baz.js
@@ -1,0 +1,13 @@
+
+import { missing } from 'appkit/foo';
+import { bar } from 'appkit/bar';
+
+var bim = {
+	property: true
+};
+
+export var baz = bim;
+
+export { bim };
+
+export default { bim: bim, baz: baz };

--- a/tests/fixtures/renamed/foo.js
+++ b/tests/fixtures/renamed/foo.js
@@ -1,0 +1,6 @@
+
+var foo = {
+	property: true
+};
+
+export default foo;


### PR DESCRIPTION
- Introduce custom ES6ModuleFile class with getModuleName override
- Allow passing moduleName function as option
- Update to es6-import-validate 0.0.3
- Bump version for publish
