### PR TITLE
Better display javascript parse errors

### DIFF
--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -57,9 +57,18 @@ module.exports = function (grunt) {
 			})
 			.catch(function (errors) {
 				// Show messages if failures
-				errors.forEach(function (err) {
-					grunt.log.error(err.name.yellow + ': '.red + err.message.yellow);
-				});
+				if(_.isArray(errors)) {
+					errors.forEach(function (err) {
+						grunt.log.error(err.name.yellow + ': '.red + err.message.yellow);
+					});
+				} else {
+					grunt.log.error(errors.name.yellow + ': '.red + errors.message.yellow);
+					grunt.log.writeln();
+					grunt.fail.fatal('Javscript parse error');
+
+					done();
+					return;
+				}
 
 				grunt.log.writeln();
 				grunt.fail.warn('Validation errors found in modules.');


### PR DESCRIPTION
This pull request just makes it clearer to the end user that something went wrong with the parsing of the import and export statements and not an actual import validation error. 

It also doesn't make it look like the grunt plugin itself is broken which is what I (naively) initially thought :-)

If there is a javascript parse error the exception displayed in the grunt plugin is this:

```
Possibly unhandled TypeError: Object Error: Line 1: Unexpected identifier has no method 'forEach'
at .../..../node_modules/grunt-es6-import-validate/tasks/validate.js:60:12
```

Signifying that it was not actually an array or errors that was returned but a single error that looks like this being seen in the underlying 'es6-import-validate' module:

```
{ [Error: Line 3: Missing from after import]
   index: 42,
   lineNumber: 3,
   column: 16,
   description: 'Missing from after import' }
```

I think this is from the parsing framework 'esprima'.

The real error might caused by something like this:

```
immport Foo from 'bar'
```
